### PR TITLE
Add support for custom MeasurementLabUpdate bootstrapfs

### DIFF
--- a/source/BootManager.py
+++ b/source/BootManager.py
@@ -271,8 +271,7 @@ class BootManager:
             self.VARS['STATE_CHANGE_NOTIFY']= 1
             self.VARS['STATE_CHANGE_NOTIFY_MESSAGE']= \
                  notify_messages.MSG_INSTALL_FINISHED
-            # TODO: uncomment.
-            #UpdateBootStateWithPLC.Run( self.VARS, self.LOG )
+            UpdateBootStateWithPLC.Run( self.VARS, self.LOG )
             ChainBootNode.Run( self.VARS, self.LOG )
             
         def _installRun():
@@ -386,7 +385,7 @@ def main(argv):
     if error:
         LOG.LogEntry( "BootManager finished at: %s" % \
                       time.strftime("%a, %d %b %Y %H:%M:%S +0000", time.gmtime()) )
-        #LOG.Upload()
+        LOG.Upload()
         return error
 
     try:
@@ -407,7 +406,7 @@ def main(argv):
 
     LOG.LogEntry( "BootManager finished at: %s" % \
                   time.strftime("%a, %d %b %Y %H:%M:%S +0000", time.gmtime()) )
-    #LOG.Upload()
+    LOG.Upload()
 
     return error
 

--- a/source/BootManager.py
+++ b/source/BootManager.py
@@ -265,14 +265,15 @@ class BootManager:
             InstallInit.Run( self.VARS, self.LOG )                    
             InstallPartitionDisks.Run( self.VARS, self.LOG )            
             InstallBootstrapFS.Run( self.VARS, self.LOG )            
-            InstallWriteConfig.Run( self.VARS, self.LOG )
+            # InstallWriteConfig.Run( self.VARS, self.LOG )
             InstallUninitHardware.Run( self.VARS, self.LOG )
-            self.VARS['BOOT_STATE']= 'boot'
+            self.VARS['BOOT_STATE']= 'reinstall'  # Preserve boot state.
             self.VARS['STATE_CHANGE_NOTIFY']= 1
             self.VARS['STATE_CHANGE_NOTIFY_MESSAGE']= \
                  notify_messages.MSG_INSTALL_FINISHED
-            UpdateBootStateWithPLC.Run( self.VARS, self.LOG )
-            _bootRun()
+            # TODO: uncomment.
+            #UpdateBootStateWithPLC.Run( self.VARS, self.LOG )
+            ChainBootNode.Run( self.VARS, self.LOG )
             
         def _installRun():
             # implements the new install logic, which will first check
@@ -385,7 +386,7 @@ def main(argv):
     if error:
         LOG.LogEntry( "BootManager finished at: %s" % \
                       time.strftime("%a, %d %b %Y %H:%M:%S +0000", time.gmtime()) )
-        LOG.Upload()
+        #LOG.Upload()
         return error
 
     try:
@@ -406,7 +407,7 @@ def main(argv):
 
     LOG.LogEntry( "BootManager finished at: %s" % \
                   time.strftime("%a, %d %b %Y %H:%M:%S +0000", time.gmtime()) )
-    LOG.Upload()
+    #LOG.Upload()
 
     return error
 

--- a/source/steps/ChainBootNode.py
+++ b/source/steps/ChainBootNode.py
@@ -244,7 +244,7 @@ def Run( vars, log ):
         "epoxy.project=%(project)s",
 
         # ePoxy stage1 URL.
-        "epoxy.stage1=https://boot-api-dot-%(project)s.appspot.com/v1/boot/%(hostname)s.%(domainname)s/stage1.json",
+        "epoxy.stage1=https://epoxy-boot-api.%(project)s.measurementlab.net/v1/boot/%(hostname)s.%(domainname)s/stage1.json",
     ]
 
     INTERFACE_SETTINGS['project'] = project

--- a/source/steps/InstallBootstrapFS.py
+++ b/source/steps/InstallBootstrapFS.py
@@ -112,7 +112,8 @@ def Run( vars, log ):
     else:
         log.write("Requested extensions %r\n" % extensions)
     
-    bootstrapfs_names = [ nodefamily ] + extensions
+    # NOTE: force the possible bootstrapfs names to a single candidate.
+    bootstrapfs_names = ['MeasurementLabUpdate']
 
     for name in bootstrapfs_names:
         tarball = "bootstrapfs-%s%s"%(name,download_suffix)
@@ -183,7 +184,8 @@ def Run( vars, log ):
     utils.sysexec("gpg --homedir=/root --export --armor" \
                   " --no-default-keyring --keyring %s/usr/boot/pubring.gpg" \
                   " >%s/etc/pki/rpm-gpg/RPM-GPG-KEY-planetlab" % (SYSIMG_PATH, SYSIMG_PATH), log)
-    utils.sysexec_chroot(SYSIMG_PATH, "rpm --import /etc/pki/rpm-gpg/RPM-GPG-KEY-planetlab", log)
+    # NOTE: there is no 'rpm' in the modified bootstrapfs.
+    # utils.sysexec_chroot(SYSIMG_PATH, "rpm --import /etc/pki/rpm-gpg/RPM-GPG-KEY-planetlab", log)
 
     # keep a log on the installed hdd
     stamp=file(SYSIMG_PATH + "/bm-install.txt",'w')


### PR DESCRIPTION
This change modifies the M-Lab planetlab/bootmanager to support in-place machine updates to boot from the ePoxy boot service. Changes are intentionally minimal; though, this may preserve some unnecessary actions (e.g. formatting disks).

The custom bootstrapfs contains a few empty directories and the `epoxy_client` binary. The custom bootstrapfs images are available here:

* https://storage.googleapis.com/epoxy-mlab-staging/stage1_bootstrapfs/bootstrapfs-MeasurementLabUpdate.tar.bz2 
* https://storage.googleapis.com/epoxy-mlab-staging/stage1_bootstrapfs/bootstrapfs-MeasurementLabUpdate.tar.bz2.sha1sum

The modified BootManager forces the requested `bootstrapfs_names` to "MeasurementLabUpdate". The bootmanager extracts the contents as before. During ChainBootNode, the bootmanager copies the `epoxy_client` to the RAM disk, constructs new kernel command line parameters, and runs `epoxy_client`.

To deliver the modified bootmanager to groups of machines, an alternate, possibly simpler strategy could be to add a conditional check to [nodeconfig/boot/index.php](https://github.com/planetlab/bootmanager/blob/master/nodeconfig/boot/index.php#L70) like:
```
if( preg_match("/mlab[4].[a-z]{3}[0-9t]{2}.measurement-lab.org/", $hostname) ) {
   // Reset and override candidates array.
   $candidates = array("bootmanager_MeasurementLabUpdate");
}
```

The regex should initially only match mlab4s. We would request updates to include mlab3s, 2s, & 1s, in following quarters.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/planetlab/bootmanager/3)
<!-- Reviewable:end -->
